### PR TITLE
feat: Experiment metrics stream

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ requires-python = ">=3.9"
 dependencies = [
     "singer-sdk~=0.44.3",
     "requests~=2.32.3",
+    "pyhumps>=3.8.0",
 ]
 
 [project.optional-dependencies]

--- a/tap_iterable/__init__.py
+++ b/tap_iterable/__init__.py
@@ -1,5 +1,1 @@
 """Tap for Iterable."""
-
-import singer_sdk.typing as th
-
-RateType = th.NumberType(minimum=0, maximum=1)

--- a/tap_iterable/__init__.py
+++ b/tap_iterable/__init__.py
@@ -1,1 +1,5 @@
 """Tap for Iterable."""
+
+import singer_sdk.typing as th
+
+RateType = th.NumberType(minimum=0, maximum=1)

--- a/tap_iterable/client.py
+++ b/tap_iterable/client.py
@@ -72,26 +72,13 @@ class IterableStream(RESTStream):
         """
         return super().get_new_paginator()
 
-    def get_url_params(
-        self,
-        context: Context | None,  # noqa: ARG002
-        next_page_token: t.Any | None,  # noqa: ANN401
-    ) -> dict[str, t.Any]:
-        """Return a dictionary of values to be used in URL parameterization.
+    @override
+    def get_url_params(self, context, next_page_token):
+        params = super().get_url_params(context, next_page_token)
 
-        Args:
-            context: The stream context.
-            next_page_token: The next page index or value.
+        if start_date := self.get_starting_timestamp(context):
+            params["startDateTime"] = start_date.strftime(r"%Y-%m-%d %H:%M:%S")
 
-        Returns:
-            A dictionary of URL query parameters.
-        """
-        params: dict = {}
-        if next_page_token:
-            params["page"] = next_page_token
-        if self.replication_key:
-            params["sort"] = "asc"
-            params["order_by"] = self.replication_key
         return params
 
     def prepare_request_payload(

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -16,7 +16,6 @@ from singer_sdk import typing as th
 from singer_sdk.streams import Stream
 from typing_extensions import override
 
-from tap_iterable import RateType
 from tap_iterable.client import IterableStream
 
 SCHEMAS_DIR = resources.files(__package__) / "schemas"
@@ -477,7 +476,7 @@ class ExperimentMetrics(IterableStream):
         th.Property("confidence", th.StringType),
         th.Property("totalEmailSends", th.IntegerType),
         th.Property("uniqueEmailSends", th.IntegerType),
-        th.Property("emailDeliveryRate", RateType),
+        th.Property("emailDeliveryRate", th.NumberType),
         th.Property("totalEmailsDelivered", th.IntegerType),
         th.Property("uniqueEmailsDelivered", th.IntegerType),
         th.Property("totalEmailOpens", th.IntegerType),
@@ -485,23 +484,23 @@ class ExperimentMetrics(IterableStream):
         th.Property("uniqueEmailOpens", th.IntegerType),
         th.Property("uniqueEmailOpensFiltered", th.IntegerType),
         th.Property("uniqueEmailOpensOrClicks", th.IntegerType),
-        th.Property("emailOpenRate", RateType),
-        th.Property("uniqueEmailOpenRate", RateType),
+        th.Property("emailOpenRate", th.NumberType),
+        th.Property("uniqueEmailOpenRate", th.NumberType),
         th.Property("totalEmailsClicked", th.IntegerType),
         th.Property("uniqueEmailClicks", th.IntegerType),
         th.Property("clicksOpens", th.NumberType),
-        th.Property("emailClickRate", RateType),
-        th.Property("uniqueEmailClickRate", RateType),
+        th.Property("emailClickRate", th.NumberType),
+        th.Property("uniqueEmailClickRate", th.NumberType),
         th.Property("totalComplaints", th.IntegerType),
-        th.Property("complaintRate", RateType),
+        th.Property("complaintRate", th.NumberType),
         th.Property("totalEmailsBounced", th.IntegerType),
         th.Property("uniqueEmailsBounced", th.IntegerType),
-        th.Property("emailBounceRate", RateType),
+        th.Property("emailBounceRate", th.NumberType),
         th.Property("totalEmailHoldout", th.IntegerType),
         th.Property("totalEmailSendSkips", th.IntegerType),
         th.Property("totalUnsubscribes", th.IntegerType),
         th.Property("uniqueUnsubscribes", th.IntegerType),
-        th.Property("emailUnsubscribeRate", RateType),
+        th.Property("emailUnsubscribeRate", th.NumberType),
         th.Property("revenue", th.NumberType),
         th.Property("totalPurchases", th.IntegerType),
         th.Property("uniquePurchases", th.IntegerType),

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -545,8 +545,7 @@ class ExperimentMetrics(IterableStream):
             value = row.pop(k)
 
             if value == "":
-                row[new_key] = None
-                continue
+                row[new_key] = value = None
 
             if value is None or not (property_schema := properties.get(new_key)):
                 continue

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -543,7 +543,7 @@ class ExperimentMetrics(IterableStream):
 
             value = row.pop(k)
 
-            if len(value) == 0:
+            if value == "":
                 value = None
 
             if value is not None:

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -571,7 +571,18 @@ class ExperimentMetrics(IterableStream):
                     d = decimal.Decimal(math.nan)
                     self.logger.debug("Handling invalid decimal '%s' as %s", value, d)
 
-                value = numeric_typecast(d) if not d.is_nan() else None
+                if d.is_nan() or d.is_infinite():
+                    value = None
+                    self.logger.debug(
+                        (
+                            "%s is not supported as a numeric value in JSON, handling "
+                            "as %s"
+                        ),
+                        d,
+                        value,
+                    )
+                else:
+                    value = numeric_typecast(d)
 
             row[new_key] = value
 

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -533,7 +533,7 @@ class ExperimentMetrics(IterableStream):
     def post_process(self, row, context=None):
         row = super().post_process(row, context=context)
 
-        properties = self.schema["properties"]
+        properties: dict = self.schema["properties"]
 
         for k in list(row.keys()):
             new_key = k.lower()
@@ -548,10 +548,8 @@ class ExperimentMetrics(IterableStream):
                 row[new_key] = None
                 continue
 
-            if value is None:
+            if value is None or not (property_schema := properties.get(new_key)):
                 continue
-
-            property_types: list[str] = properties[new_key]["type"]
 
             numeric_typecasts: dict[th._NumericType] = {
                 th.IntegerType: int,
@@ -562,7 +560,7 @@ class ExperimentMetrics(IterableStream):
                 (
                     numeric_typecasts[nt]
                     for nt in numeric_typecasts
-                    if nt.__type_name__ in property_types
+                    if nt.__type_name__ in property_schema["type"]
                 ),
                 None,
             )  # get the first matching typecast if one exists

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -517,6 +517,7 @@ class ExperimentMetrics(IterableStream):
     ).to_dict()
 
     primary_keys = ("campaignId", "experimentId", "templateId")
+    replication_key = "lastModified"
 
     # disable default pagination logic as this endpoint response is not JSON (and does
     # not support pagination anyway)

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -224,9 +224,7 @@ class _ExportStream(IterableStream):
         params = super().get_url_params(context, next_page_token)
         params["dataTypeName"] = self.data_type_name
 
-        if start_date := self.get_starting_timestamp(context):
-            params["startDateTime"] = start_date.strftime(r"%Y-%m-%d %H:%M:%S")
-        else:
+        if "startDateTime" not in params:
             params["range"] = "All"
 
         return params

--- a/tap_iterable/tap.py
+++ b/tap_iterable/tap.py
@@ -75,6 +75,7 @@ class TapIterable(Tap):
             streams.WebPushSendSkipStream(self),
             streams.UsersStream(self),
             streams.CustomEventStream(self),
+            streams.ExperimentMetrics(self),
         ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -452,6 +452,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyhumps"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/83/fa6f8fb7accb21f39e8f2b6a18f76f6d90626bdb0a5e5448e5cc9b8ab014/pyhumps-3.8.0.tar.gz", hash = "sha256:498026258f7ee1a8e447c2e28526c0bea9407f9a59c03260aee4bd6c04d681a3", size = 9018 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/11/a1938340ecb32d71e47ad4914843775011e6e9da59ba1229f181fef3119e/pyhumps-3.8.0-py3-none-any.whl", hash = "sha256:060e1954d9069f428232a1adda165db0b9d8dfdce1d265d36df7fbff540acfd6", size = 6095 },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -890,6 +899,7 @@ name = "tap-iterable"
 version = "0.0.1"
 source = { editable = "." }
 dependencies = [
+    { name = "pyhumps" },
     { name = "requests" },
     { name = "singer-sdk" },
 ]
@@ -908,6 +918,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fs-s3fs", marker = "extra == 's3'", specifier = "~=1.1.1" },
+    { name = "pyhumps", specifier = ">=3.8.0" },
     { name = "requests", specifier = "~=2.32.3" },
     { name = "singer-sdk", specifier = "~=0.44.3" },
 ]


### PR DESCRIPTION
Adds an `experiment_metrics` stream, based on https://api.iterable.com/api/docs#experiments_metrics.

Reference:
- https://support.iterable.com/hc/en-us/articles/205480325-Experiments-Overview
- https://support.iterable.com/hc/en-us/articles/213805923-Metric-Definitions