### PR TITLE
Handle empty campaign responses

### DIFF
--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -85,14 +85,16 @@ class CampaignsStream(IterableStream):
     @override
     def parse_response(self, response):
         last_record = None
+
         for record in super().parse_response(response):
             last_record = record
             yield record
 
         # make sure we process the remaining buffer entries
         self._campaign_ids_buffer.finalize()
+
         # yield last record again to force child context generation
-        if last_record is not None:
+        if last_record:
             yield last_record
 
     @override

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -84,12 +84,16 @@ class CampaignsStream(IterableStream):
 
     @override
     def parse_response(self, response):
+        last_record = None
         for record in super().parse_response(response):
+            last_record = record
             yield record
 
         # make sure we process the remaining buffer entries
         self._campaign_ids_buffer.finalize()
-        yield record  # yield last record again to force child context generation
+        # yield last record again to force child context generation
+        if last_record is not None:
+            yield last_record
 
     @override
     def generate_child_contexts(self, record, context):


### PR DESCRIPTION
## Summary
- prevent `CampaignsStream.parse_response` from raising `UnboundLocalError`
- clarify why the final record is yielded again

## Testing
- `ruff check tap_iterable/streams.py`
- `ruff format tap_iterable/streams.py`
- `mypy tap_iterable/streams.py` *(fails: ModuleNotFoundError: No module named 'singer_sdk')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'singer_sdk')*

------
https://chatgpt.com/codex/tasks/task_b_6842e88cf7c88327a4ef36103b336e63