### PR TITLE
fix: `AttributeError: 'NoneType' object has no attribute 'copy'` for `users` stream

### DIFF
--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -540,7 +540,10 @@ class UsersStream(_ExportStream):
 
     @override
     def post_process(self, row, context=None):
-        row: dict[str] = super().post_process(row, context)
+        row = super().post_process(row, context)
+
+        if row is None:
+            return None
 
         # loosely following convention from https://api.iterable.com/api/docs#users_getUserById,
         # use a `dataFields` schema property as to encapsulate all project-specific user


### PR DESCRIPTION
This is caused by `UsersStream.post_process` not respecting `None` return value from `_ExportStream.post_process` indicating user rows should be filtered out, as per 5a5a041d098bff6f584499a0a3154c02f9b1530b.