### PR TITLE
fix: Too many campaign IDs requested for experiment metrics API endpoint

### DIFF
--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -79,7 +79,7 @@ class CampaignsStream(IterableStream):
     @override
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self._campaign_ids_buffer = BufferDeque(maxlen=400)
+        self._campaign_ids_buffer = BufferDeque(maxlen=200)
 
     @override
     def parse_response(self, response):


### PR DESCRIPTION
New issue around usage of the Iterable experiment metrics API endpoint: 

```
singer_sdk.exceptions.FatalAPIError: 400 Client Error: Bad Request for path: /api/experiments/metrics, content is Too many experiments requested. Maximum allowed is 200 campaigns or experiments.
```