### PR TITLE
fix: `ip` property `format` causing downstream issues with database targets

### DIFF
--- a/tap_iterable/schemas/users.json
+++ b/tap_iterable/schemas/users.json
@@ -247,8 +247,7 @@
       "type": [
         "null",
         "string"
-      ],
-      "format": "ipv4"
+      ]
     },
     "locale": {
       "type": [


### PR DESCRIPTION
`ip` value can be an IPv4 or IPv6 address, each of which has a different length. Given `ipv4` format, attempting to load IPv6 values can cause errors like

```
sqlalchemy.exc.ProgrammingError: (snowflake.connector.errors.ProgrammingError) 100078 (22000): String '2001:0DB8:276d:95b0:034b:55d4:063c:7412' is too long and would be truncated
```

Let's drop the format for now.