### PR TITLE
fix: URI too long error for experiment metrics stream

### DIFF
--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -79,7 +79,7 @@ class CampaignsStream(IterableStream):
     @override
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self._campaign_ids_buffer = BufferDeque(maxlen=200)
+        self._campaign_ids_buffer = BufferDeque(maxlen=50)
 
     @override
     def parse_response(self, response):


### PR DESCRIPTION
```
singer_sdk.exceptions.FatalAPIError: 414 Client Error: URI Too Long for path: /api/experiments/metrics, content is URI length exceeds the configured limit of 2048 characters
```

Perhaps this is a newly-enforced limit across all Iterable API endpoints - the way we request experiment metrics data for multiple campaigns violates this currently.

N.B. this introduces a performance regression as the tap will make up to 4x as many requests to sync experiment metrics data than previously.